### PR TITLE
enhancement: add auto-correct to hero name inputs on Element blur

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,6 +25,47 @@ const heroInputs = [
 let validHeroNames = new Set(); // To store valid hero names for validation
 // let heroIconMap = {}; // Removed: No longer fetching icons
 
+const HERO_ABBREVIATIONS = {
+    'Ancient Apparition': genAbbreviations('aa'),
+    'Anti-Mage': genAbbreviations('am'),
+    'Bounty Hunter': genAbbreviations('bh'),
+    'Chaos Knight': genAbbreviations('ck'),
+    'Crystal Maiden': genAbbreviations('cm'),
+    'Dark Seer': genAbbreviations('ds'),
+    'Death Prophet': genAbbreviations('dp'),
+    'Dragon Knight': genAbbreviations('dk'),
+    'Elder Titan': genAbbreviations('et'),
+    'Faceless Void': genAbbreviations('fv'),
+    'Keeper of the Light': ['kotl'],
+    'Legion Commander': genAbbreviations('lc'),
+    'Lone Druid': genAbbreviations('ld'),
+    'Monkey King': genAbbreviations('mk'),
+    'Nature\'s Prophet': genAbbreviations('np'),
+    'Night Stalker': genAbbreviations('ns'),
+    'Outworld Destroyer': genAbbreviations('od'),
+    'Phantom Assassin': genAbbreviations('pa'),
+    'Phantom Lancer': genAbbreviations('pl'),
+    'Queen of Pain': genAbbreviations('qop'),
+    'Sand King': genAbbreviations('sk'),
+    'Shadow Demon': genAbbreviations('sd'),
+    'Shadow Fiend': genAbbreviations('sf'),
+    'Skywrath Mage': genAbbreviations('sm'),
+    'Spirit Breaker': genAbbreviations('sb'),
+    'Templar Assassin': genAbbreviations('ta'),
+    'Windranger': genAbbreviations('wr'),
+    'Winter Wyvern': genAbbreviations('ww'),
+    'Witch Doctor': genAbbreviations('wd'),
+    'Wraith King': genAbbreviations('wk')
+};
+
+function genAbbreviations(baseAbbr) {
+    return [
+        baseAbbr.toUpperCase(),
+        baseAbbr.charAt(0).toUpperCase() + baseAbbr.slice(1).toLowerCase(),
+        baseAbbr
+    ];
+}
+
 // Function to fetch heroes and populate the datalist + icon map
 async function populateHeroData() {
     try {
@@ -61,6 +102,12 @@ async function populateHeroData() {
 }
 
 function autoCorrectInputs(input) {
+    for (const [heroName, abbrSet] of Object.entries(HERO_ABBREVIATIONS)) {
+        if (abbrSet.includes(input.value.trim())) {
+            input.value = heroName;
+            break;
+        }
+    }
     const separator = input.value.includes('-') ? '-' : ' ' // Anti-Mage
 
     let heroName = input.value

--- a/script.js
+++ b/script.js
@@ -60,6 +60,31 @@ async function populateHeroData() {
     }
 }
 
+function autoCorrectInputs(input) {
+    const separator = input.value.includes('-') ? '-' : ' ' // Anti-Mage
+
+    let heroName = input.value
+        .trim()
+        .replace(/\s+/g, ' ') // handle multiple spaces between words; e.g. 'Phantom  Lancer'
+
+    if (heroName.toLowerCase() === 'keeper of the light') {
+        input.value = 'Keeper of the Light'
+    } else {
+        const splitLength = heroName.split(separator).length;
+        if (splitLength <= 2) {
+            heroName = heroName
+                .split(separator)
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+                .join(separator);
+        }
+
+        // Auto correct hero name if possible
+        if (validHeroNames.has(heroName)) {
+            input.value = heroName;
+        }
+    }
+}
+
 // Function to validate hero inputs (with real-time feedback hints)
 function validateHeroInputs(isFinalCheck = false) {
     let isValid = true;
@@ -113,6 +138,7 @@ document.addEventListener('DOMContentLoaded', populateHeroData);
 // Real-time validation hints on input blur (losing focus)
 heroInputs.forEach(input => {
     input.addEventListener('blur', () => {
+        autoCorrectInputs(input);
         validateHeroInputs(false); // Run validation, but don't show main error message yet
     });
     // Clear specific input error on typing
@@ -258,4 +284,4 @@ clearFormBtn.addEventListener('click', () => {
     outputDiv.innerHTML = ''; // Clear results area
     outputDiv.style.display = 'block'; // Ensure output area is visible
     loadingSpinner.style.display = 'none'; // Ensure spinner is hidden
-}); 
+});


### PR DESCRIPTION
This allows inputting case-insensitive hero names by converting them to valid names on Element blur. Also converts commonly used hero abbreviations to their respectively valid name (e.g. 'dk' -> 'Dragon Knight').

Cool project!